### PR TITLE
Add --config-file option

### DIFF
--- a/mutacc_auto/cli/extract_command.py
+++ b/mutacc_auto/cli/extract_command.py
@@ -111,12 +111,16 @@ def extract_command(ctx,
     mutacc_config = mutacc_config or ctx.obj.get('mutacc_config')
     mutacc_binary = ctx.obj.get('mutacc_binary')
 
+    slurm_config = {}
+    if ctx.obj.get('slurm'):
+        slurm_config = ctx.obj['slurm']
+
     slurm_options = {}
-    slurm_options['log_directory'] = log_directory or ctx.obj['slurm'].get('log_directory')
-    slurm_options['email'] = email or ctx.obj['slurm'].get('email')
-    slurm_options['time'] = time or ctx.obj['slurm'].get('time')
-    slurm_options['account'] = account or ctx.obj['slurm'].get('account')
-    slurm_options['priority'] = priority or ctx.obj['slurm'].get('priority')
+    slurm_options['log_directory'] = log_directory or slurm_config.get('log_directory')
+    slurm_options['email'] = email or slurm_config.get('email')
+    slurm_options['time'] = time or slurm_config.get('time')
+    slurm_options['account'] = account or slurm_config.get('account')
+    slurm_options['priority'] = priority or slurm_config.get('priority')
 
 
 
@@ -140,8 +144,6 @@ def extract_command(ctx,
                     case_input['padding'],
                     environment,
                     slurm_options,
-                    log_directory,
-                    email=email,
                     conda=conda,
                     dry=dry,
                     mutacc_binary=mutacc_binary
@@ -156,7 +158,7 @@ def extract_command(ctx,
                 with open(case_input['input_file']) as input_handle:
 
                     LOG.info("INPUT FILE {}\n{}".format(case_input['input_file'],input_handle.read()))
-                    
+
 
                 with open(case_input['input_file']) as input_handle:
                     input_file = yaml.load(input_handle)

--- a/mutacc_auto/cli/extract_command.py
+++ b/mutacc_auto/cli/extract_command.py
@@ -22,63 +22,103 @@ def parse_path(ctx, param, value):
 
 @click.command('extract')
 @click.option('-c','--case-id',
-type=str,
-help="case id used in scout and housekeeper")
-@click.option('-d','--days-ago',
-type=int,
-help="days since last update of case")
-@click.option('-e','--environment',
-type=str,
-help="conda environment used for mutacc"
+    type=str,
+    help="case id used in scout and housekeeper"
 )
-@click.option('-C','--config-file',
-type=click.Path(exists=True),
-callback=parse_path,
-help="configuration file used for mutacc"
+@click.option('-d','--days-ago',
+    type=int,
+    help="days since last update of case"
+)
+@click.option('-e','--environment',
+    type=str,
+    help="conda environment used for mutacc"
+)
+@click.option('-C','--mutacc-config',
+    type=click.Path(exists=True),
+    callback=parse_path,
+    help="configuration file used for mutacc"
 )
 @click.option('-L', '--log-directory',
-type=click.Path(exists=True),
-callback=parse_path,
-help="Directory for slurm logs")
+    type=click.Path(exists=True),
+    callback=parse_path,
+    help="Directory for slurm logs"
+)
 @click.option('-E', '--email',
-type=str,
-help="email to notify")
+    type=str,
+    help="email to notify"
+)
+@click.option('-t', '--time',
+    type=str,
+    help="Time for slurm jobs"
+)
+@click.option('-a', '--account',
+    type=str,
+    help="Account for slurm job"
+)
+@click.option('-P','--priority',
+    type=str,
+    help="priority for slurm job"
+)
 @click.option('-p','--padding',
-type=int,
-help="padding for genomic regions. this defaults to 0 for WES cases")
+    type=int,
+    help="padding for genomic regions. this defaults to 0 for WES cases"
+)
 @click.option('-D','--dry',
-is_flag=True,
-help="dry run")
+    is_flag=True,
+    help="dry run"
+)
 @click.option('-V','--verbose',
-is_flag=True,
-help="verbose")
+    is_flag=True,
+    help="verbose"
+)
 @click.option('-k', '--conda',
-is_flag=True,
-help="Use 'conda activate' to source environment")
+    is_flag=True,
+    help="Use 'conda activate' to source environment")
 @click.option('--scout-config',
-type=click.Path(exists=True),
-callback=parse_path,
-help="configuration file used for scout"
+    type=click.Path(exists=True),
+    callback=parse_path,
+    help="configuration file used for scout"
 )
 @click.option('--hk-config',
-type=click.Path(exists=True),
-callback=parse_path,
-help="configuration file used for housekeeper"
+    type=click.Path(exists=True),
+    callback=parse_path,
+    help="configuration file used for housekeeper"
 )
 @click.pass_context
 def extract_command(ctx,
                     case_id,
                     days_ago,
                     environment,
-                    config_file,
+                    mutacc_config,
                     log_directory,
                     email,
+                    time,
+                    account,
+                    priority,
                     padding,
                     dry,
                     verbose,
                     conda,
                     scout_config,
                     hk_config):
+
+
+
+    scout_config = scout_config or ctx.obj.get('scout_config')
+    scout_binary = ctx.obj.get('scout_binary')
+    hk_config = hk_config or ctx.obj.get('housekeeper_config')
+    hk_binary = ctx.obj.get('housekeeper_binary')
+    mutacc_config = mutacc_config or ctx.obj.get('mutacc_config')
+    mutacc_binary = ctx.obj.get('mutacc_binary')
+
+    slurm_options = {}
+    slurm_options['log_directory'] = log_directory or ctx.obj['slurm'].get('log_directory')
+    slurm_options['email'] = email or ctx.obj['slurm'].get('email')
+    slurm_options['time'] = time or ctx.obj['slurm'].get('time')
+    slurm_options['account'] = account or ctx.obj['slurm'].get('account')
+    slurm_options['priority'] = priority or ctx.obj['slurm'].get('priority')
+
+
 
     #Create a temporary dir to store created vcf, yaml, and script files
     with TemporaryDirectory() as tmp_dir:
@@ -88,28 +128,40 @@ def extract_command(ctx,
         #Prepare input for case with case_id or days since updated
         inputs = get_inputs(tmp_dir, case_id=case_id, days_ago=days_ago,
                             padding = padding, scout_config=scout_config,
-                            hk_config=hk_config)
+                            scout_binary=scout_binary, hk_config=hk_config,
+                            hk_binary=hk_binary)
 
         for case_input in inputs:
             #Extract reads for every case
             sbatch_script = run_mutacc_extract(
                     tmp_dir,
-                    config_file,
+                    mutacc_config,
                     case_input['input_file'],
                     case_input['padding'],
                     environment,
+                    slurm_options,
                     log_directory,
                     email=email,
                     conda=conda,
-                    dry=dry
+                    dry=dry,
+                    mutacc_binary=mutacc_binary
                 )
 
             if verbose:
 
-                with open(case_input['input_file']) as input_handle:
-
-                    LOG.info("\n{}".format(input_handle.read()))
-
                 with open(sbatch_script) as sbatch_handle:
 
-                    LOG.info("\n{}".format(sbatch_handle.read()))
+                    LOG.info("SBATCH SCRIPT {}\n{}".format(sbatch_script, sbatch_handle.read()))
+
+                with open(case_input['input_file']) as input_handle:
+
+                    LOG.info("INPUT FILE {}\n{}".format(case_input['input_file'],input_handle.read()))
+                    
+
+                with open(case_input['input_file']) as input_handle:
+                    input_file = yaml.load(input_handle)
+                vcf_file = input_file['variants']
+
+                with open(vcf_file) as vcf_handle:
+
+                    LOG.info("VCF FILE {}\n{}".format(vcf_file, vcf_handle.read()))

--- a/mutacc_auto/cli/root.py
+++ b/mutacc_auto/cli/root.py
@@ -1,6 +1,8 @@
 import click
 import logging
 import coloredlogs
+from pathlib import Path
+import yaml
 
 from mutacc_auto import __version__
 from .extract_command import extract_command
@@ -9,14 +11,27 @@ from .import_command import import_command
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 LOG = logging.getLogger(__name__)
 
+def parse_path(ctx, param, value):
+
+    if value:
+        value = str(Path(str(value)).expanduser().absolute().resolve())
+    return value
+
 @click.group()
 @click.option('--loglevel', default='INFO', type=click.Choice(LOG_LEVELS))
+@click.option('--config-file', type=click.Path(exists=True), callback = parse_path)
 @click.version_option(__version__)
 @click.pass_context
-def cli(context, loglevel):
+def cli(ctx, loglevel, config_file):
 
     coloredlogs.install(level = loglevel)
     LOG.info("Running mutacc_auto")
+
+    if config_file:
+        with open(config_file, 'r') as in_handle:
+            config = yaml.load(in_handle)
+
+    ctx.obj = config
 
 cli.add_command(extract_command)
 cli.add_command(import_command)

--- a/mutacc_auto/cli/root.py
+++ b/mutacc_auto/cli/root.py
@@ -27,6 +27,7 @@ def cli(ctx, loglevel, config_file):
     coloredlogs.install(level = loglevel)
     LOG.info("Running mutacc_auto")
 
+    config = {}
     if config_file:
         with open(config_file, 'r') as in_handle:
             config = yaml.load(in_handle)

--- a/mutacc_auto/commands/housekeeper_command.py
+++ b/mutacc_auto/commands/housekeeper_command.py
@@ -6,10 +6,12 @@ BASE_COMMAND = "housekeeper"
 #Inherit from BaseCommand
 class HousekeeperCommand(BaseCommand):
 
-    def __init__(self, case_id, config_file=None):
+    def __init__(self, case_id, config_file=None, hk_binary=None):
 
         super(HousekeeperCommand, self).__init__(BASE_COMMAND)
 
+        if hk_binary:
+            self.command = [hk_binary]
         if config_file:
 
             self.add_option('config', value=str(config_file))

--- a/mutacc_auto/commands/mutacc_command.py
+++ b/mutacc_auto/commands/mutacc_command.py
@@ -11,19 +11,17 @@ class MutaccCommand(BaseCommand):
 
         super(MutaccCommand, self).__init__(BASE_COMMAND)
 
+        self.command = [BASE_COMMAND]
         if mutacc_binary:
             self.command = [mutacc_binary]
 
         self.add_option('config-file', value=config_file)
 
-class MutAccExract(MutaccCommand):
+class MutaccExtract(MutaccCommand):
 
     def __init__(self, config_file, padding, case_file, mutacc_binary=None):
 
-        super(MutAccExract, self).__init__(config_file)
-
-        if mutacc_binary:
-            self.command = [mutacc_binary]
+        super(MutaccExtract, self).__init__(config_file, mutacc_binary=mutacc_binary)
 
         self.add_subcommand('extract')
         self.add_option('padding', value=str(padding))
@@ -34,10 +32,7 @@ class MutaccImport(MutaccCommand):
 
     def __init__(self, config_file, extracted_case_file, mutacc_binary=None):
 
-        super(MutaccImport, self).__init__(config_file)
-
-        if mutacc_binary:
-            self.command = [mutacc_binary]
+        super(MutaccImport, self).__init__(config_file, mutacc_binary=mutacc_binary)
 
         self.add_subcommand('db')
         self.add_subcommand('import')

--- a/mutacc_auto/commands/mutacc_command.py
+++ b/mutacc_auto/commands/mutacc_command.py
@@ -7,17 +7,23 @@ BASE_COMMAND = "mutacc"
 #Inherit from BaseCommand
 class MutaccCommand(BaseCommand):
 
-    def __init__(self, config_file):
+    def __init__(self, config_file, mutacc_binary=None):
 
         super(MutaccCommand, self).__init__(BASE_COMMAND)
+
+        if mutacc_binary:
+            self.command = [mutacc_binary]
 
         self.add_option('config-file', value=config_file)
 
 class MutAccExract(MutaccCommand):
 
-    def __init__(self, config_file, padding, case_file):
+    def __init__(self, config_file, padding, case_file, mutacc_binary=None):
 
         super(MutAccExract, self).__init__(config_file)
+
+        if mutacc_binary:
+            self.command = [mutacc_binary]
 
         self.add_subcommand('extract')
         self.add_option('padding', value=str(padding))
@@ -26,9 +32,12 @@ class MutAccExract(MutaccCommand):
 
 class MutaccImport(MutaccCommand):
 
-    def __init__(self, config_file, extracted_case_file):
+    def __init__(self, config_file, extracted_case_file, mutacc_binary=None):
 
         super(MutaccImport, self).__init__(config_file)
+
+        if mutacc_binary:
+            self.command = [mutacc_binary]
 
         self.add_subcommand('db')
         self.add_subcommand('import')

--- a/mutacc_auto/commands/scout_command.py
+++ b/mutacc_auto/commands/scout_command.py
@@ -14,9 +14,12 @@ class ScoutCommand(BaseCommand):
 
 class ScoutExportCases(ScoutCommand):
 
-    def __init__(self, case_id=None, config_file=None):
+    def __init__(self, case_id=None, config_file=None, scout_binary=None):
 
         super(ScoutExportCases, self).__init__()
+
+        if scout_binary:
+            self.command = [scout_binary]
 
         if config_file:
 
@@ -33,9 +36,12 @@ class ScoutExportCases(ScoutCommand):
 
 class ScoutExportCausativeVariants(ScoutCommand):
 
-    def __init__(self, case_id, json_output = True, config_file=None):
+    def __init__(self, case_id, json_output = True, config_file=None, scout_binary=None):
 
         super(ScoutExportCausativeVariants, self).__init__()
+        
+        if scout_binary:
+            self.command = [scout_binary]
 
         if config_file:
 

--- a/mutacc_auto/files/constants.py
+++ b/mutacc_auto/files/constants.py
@@ -17,16 +17,16 @@ MAIL_FAIL = 'FAIL'
 MAIL_END = 'END'
 
 #SOME DEFAULT SBATCH OPTIONS
-# (OPTION, VALUE)
-HEADER_OPTIONS = (
-    ('A', ACCOUNT),
-    ('n', NODES),
-    ('t', TIME),
-    ('J', JOBNAME),
-    ('qos', PRIORITY),
-    ('mail-type', MAIL_FAIL),
-    ('mail-type', MAIL_END)
-)
+# OPTION_NAME: (OPTION, VALUE)
+HEADER_OPTIONS = {
+    'account': ('A', ACCOUNT),
+    'nodes': ('n', NODES),
+    'time': ('t', TIME),
+    'jobname': ('J', JOBNAME),
+    'priority': ('qos', PRIORITY),
+    'mail_fail': ('mail-type', MAIL_FAIL),
+    'mail_end': ('mail-type', MAIL_END)
+}
 
 SOURCE_ACTIVATE = "source activate"
 CONDA_ACTIVATE = "conda activate"

--- a/mutacc_auto/files/sbatch.py
+++ b/mutacc_auto/files/sbatch.py
@@ -25,7 +25,7 @@ class SbatchScript():
     """
 
     @staticmethod
-    def get_header(slurm_options, log_directory, email=None):
+    def get_header(slurm_options):
 
         """
             Returns header to be printed in sbatch scripts
@@ -96,7 +96,7 @@ class SbatchScript():
         return SHEBANG
 
 
-    def __init__(self, job_directory, environment, slurm_options, log_directory, email=None, conda=False):
+    def __init__(self, job_directory, environment, slurm_options, conda=False):
 
         """
             Args:
@@ -112,7 +112,7 @@ class SbatchScript():
                                         delete = False
                                         )
         self.shebang = self.get_shebang()
-        self.header = self.get_header(slurm_options, log_directory, email=email)
+        self.header = self.get_header(slurm_options)
         self.environment = self.get_environment(environment, conda)
 
         #Write sections in script

--- a/mutacc_auto/recipes/extract_recipe.py
+++ b/mutacc_auto/recipes/extract_recipe.py
@@ -9,6 +9,7 @@ LOG = logging.getLogger(__name__)
 def write_sbatch_script(tmp_dir,
                         environment,
                         mutacc_extract_command,
+                        slurm_options,
                         log_directory,
                         email,
                         conda=False):
@@ -31,6 +32,7 @@ def write_sbatch_script(tmp_dir,
     with SbatchScript(
             tmp_dir,
             environment,
+            slurm_options,
             log_directory,
             email=email,
             conda=conda
@@ -44,7 +46,7 @@ def write_sbatch_script(tmp_dir,
 
 
 
-def get_mutacc_extract_command(mutacc_conf, input_file, padding):
+def get_mutacc_extract_command(mutacc_conf, input_file, padding, mutacc_binary=None):
     """
         Writes the mutacc command
 
@@ -57,7 +59,7 @@ def get_mutacc_extract_command(mutacc_conf, input_file, padding):
             mutacc_extract_command (str): mutacc command to be run for extraction
     """
 
-    mutacc_extract_command = MutAccExract(mutacc_conf, padding, input_file)
+    mutacc_extract_command = MutAccExract(mutacc_conf, padding, input_file, mutacc_binary=mutacc_binary)
 
     return str(mutacc_extract_command)
 
@@ -79,15 +81,17 @@ def sbatch_run(sbatch_script_path, dry=False):
 
 
 def run_mutacc_extract(tmp_dir,
-                       mutacc_conf,
+                       mutacc_config,
                        input_file,
                        padding,
                        environment,
+                       slurm_options,
                        log_directory,
                        email,
                        conda=False,
                        wait=False,
-                       dry=False):
+                       dry=False,
+                       mutacc_binary=None):
 
     """
         Function to extract reads from case
@@ -95,11 +99,12 @@ def run_mutacc_extract(tmp_dir,
 
     """
 
-    mutacc_extract_command = get_mutacc_extract_command(mutacc_conf, input_file, padding)
+    mutacc_extract_command = get_mutacc_extract_command(mutacc_config, input_file, padding, mutacc_binary=mutacc_binary)
 
     sbatch_script_path = write_sbatch_script(tmp_dir,
                                              environment,
                                              mutacc_extract_command,
+                                             slurm_options,
                                              log_directory,
                                              email,
                                              conda)

--- a/mutacc_auto/recipes/extract_recipe.py
+++ b/mutacc_auto/recipes/extract_recipe.py
@@ -1,6 +1,6 @@
 import logging
 
-from mutacc_auto.commands.mutacc_command import MutAccExract
+from mutacc_auto.commands.mutacc_command import MutaccExtract
 from mutacc_auto.commands.sbatch_command import SbatchCommand
 from mutacc_auto.files.sbatch import SbatchScript
 
@@ -10,8 +10,6 @@ def write_sbatch_script(tmp_dir,
                         environment,
                         mutacc_extract_command,
                         slurm_options,
-                        log_directory,
-                        email,
                         conda=False):
 
     """
@@ -33,8 +31,6 @@ def write_sbatch_script(tmp_dir,
             tmp_dir,
             environment,
             slurm_options,
-            log_directory,
-            email=email,
             conda=conda
         ) as sbatch_handle:
 
@@ -59,7 +55,7 @@ def get_mutacc_extract_command(mutacc_conf, input_file, padding, mutacc_binary=N
             mutacc_extract_command (str): mutacc command to be run for extraction
     """
 
-    mutacc_extract_command = MutAccExract(mutacc_conf, padding, input_file, mutacc_binary=mutacc_binary)
+    mutacc_extract_command = MutaccExtract(mutacc_conf, padding, input_file, mutacc_binary=mutacc_binary)
 
     return str(mutacc_extract_command)
 
@@ -86,8 +82,6 @@ def run_mutacc_extract(tmp_dir,
                        padding,
                        environment,
                        slurm_options,
-                       log_directory,
-                       email,
                        conda=False,
                        wait=False,
                        dry=False,
@@ -105,8 +99,6 @@ def run_mutacc_extract(tmp_dir,
                                              environment,
                                              mutacc_extract_command,
                                              slurm_options,
-                                             log_directory,
-                                             email,
                                              conda)
 
 

--- a/mutacc_auto/recipes/input_recipe.py
+++ b/mutacc_auto/recipes/input_recipe.py
@@ -14,7 +14,7 @@ PADDING = 600
 
 LOG = logging.getLogger(__name__)
 
-def get_cases(case_id = None, days_ago = None, scout_config=None):
+def get_cases(case_id = None, days_ago = None, scout_config=None, scout_binary=None):
 
     """
         Get cases from scout
@@ -26,13 +26,17 @@ def get_cases(case_id = None, days_ago = None, scout_config=None):
         Returns:
             cases (list(dict)): list of cases represented as dictionaries
     """
-    scout_case_command = ScoutExportCases(case_id = case_id, config_file=scout_config)
+    scout_case_command = ScoutExportCases(
+        case_id = case_id,
+        config_file=scout_config,
+        scout_binary=scout_binary
+    )
     scout_output = scout_case_command.check_output()
     cases = get_cases_from_scout(scout_output, days_ago)
 
     return cases
 
-def get_bams(case_id, hk_config=None):
+def get_bams(case_id, hk_config=None, hk_binary=None):
 
     """
         Get bam files from housekeeper
@@ -44,7 +48,11 @@ def get_bams(case_id, hk_config=None):
             bam_paths (dict): dict with paths to bam for each sample
     """
 
-    housekeeper_command = HousekeeperCommand(case_id=case_id, config_file=hk_config)
+    housekeeper_command = HousekeeperCommand(
+        case_id=case_id,
+        config_file=hk_config,
+        hk_binary=hk_binary
+    )
     hk_output = housekeeper_command.check_output()
     ###
     #hk_out = subprocess.check_output(['cat', '/Users/adam.rosenbaum/develop/mutacc_auto/tests/fixtures/HK_output_test.txt'])
@@ -54,7 +62,7 @@ def get_bams(case_id, hk_config=None):
 
     return bam_paths
 
-def write_vcf(case_id, directory, scout_config=None):
+def write_vcf(case_id, directory, scout_config=None, scout_binary=None):
 
     """
         Writes vcf file from scout output
@@ -68,7 +76,11 @@ def write_vcf(case_id, directory, scout_config=None):
         'w'
         ) as vcf_handle:
 
-        vcf_command = ScoutExportCausativeVariants(case_id, config_file=scout_config)
+        vcf_command = ScoutExportCausativeVariants(
+            case_id,
+            config_file=scout_config,
+            scout_binary=scout_binary
+        )
         vcf_scout_output = vcf_command.check_output()
         vcf_content = get_vcf_from_json(vcf_scout_output)
         vcf_handle.write(vcf_content)
@@ -117,7 +129,7 @@ def get_analysis_type(case):
     return analysis_type
 
 def get_inputs(tmp_dir ,case_id = None, days_ago = None, padding = None,
-    scout_config=None, hk_config=None):
+    scout_config=None, scout_binary=None, hk_config=None, hk_binary = None):
 
     """
         Get input data for each case
@@ -132,7 +144,7 @@ def get_inputs(tmp_dir ,case_id = None, days_ago = None, padding = None,
             inputs (list(dict)): List of dictionaries with path to input file,
                                  and padding for each case
     """
-    cases = get_cases(case_id, days_ago, scout_config=scout_config)
+    cases = get_cases(case_id, days_ago, scout_config=scout_config, scout_binary=scout_binary)
 
     inputs = []
 
@@ -143,9 +155,9 @@ def get_inputs(tmp_dir ,case_id = None, days_ago = None, padding = None,
         #case_id = case['display_name']
         case_id = case['_id']
 
-        bam_paths = get_bams(case_id, hk_config=hk_config)
+        bam_paths = get_bams(case_id, hk_config=hk_config, hk_binary=hk_binary)
 
-        vcf_path = write_vcf(case_id, tmp_dir, scout_config=scout_config)
+        vcf_path = write_vcf(case_id, tmp_dir, scout_config=scout_config, scout_binary=scout_binary)
 
         try:
             case_dict = get_case(case, bam_paths, vcf_path)

--- a/tests/cli/test_extract_command.py
+++ b/tests/cli/test_extract_command.py
@@ -15,6 +15,7 @@ SBATCH_TEMPLATE = "tests/fixtures/sbatch_template.txt"
 def test_extract_command(
         mock_extract,
         mock_inputs,
+        configuration_file,
         tmpdir
     ):
 
@@ -33,10 +34,11 @@ def test_extract_command(
 
     runner = CliRunner()
     result = runner.invoke(cli, [
+            '--config-file', configuration_file,
             'extract',
             '--case-id', 'test_id',
             '--environment', 'env',
-            '--config-file', conf_path,
+            '--mutacc-config', conf_path,
             '--log-directory', str(tmp_dir),
             '--email', 'email@email.com',
             '--dry',
@@ -50,7 +52,7 @@ def test_extract_command(
             'extract',
             '--days-ago', '300',
             '--environment', 'env',
-            '--config-file', conf_path,
+            '--mutacc-config', conf_path,
             '--log-directory', tmp_dir
         ]
     )

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -4,8 +4,9 @@ from mock import patch
 
 from mutacc_auto.commands.command import Command
 from mutacc_auto.commands.sbatch_command import SbatchCommand
-from mutacc_auto.commands.scout_command import ScoutExportCases, ScoutExportCausativeVariants
+from mutacc_auto.commands.scout_command import (ScoutExportCases, ScoutExportCausativeVariants)
 from mutacc_auto.commands.housekeeper_command import HousekeeperCommand
+from mutacc_auto.commands.mutacc_command import (MutaccExtract, MutaccImport)
 
 def test_Command():
 
@@ -48,14 +49,46 @@ def test_ScoutExportCases():
 
     assert str(command) == "scout --config config_file export cases --json --finished"
 
+    command = ScoutExportCases(config_file='config_file', scout_binary='/path/to/scout')
+
+    assert str(command) == "/path/to/scout --config config_file export cases --json --finished"
+
 def test_ScoutExportCausativeVariants():
 
     command = ScoutExportCausativeVariants(case_id='case_id',config_file='config_file')
 
     assert str(command) == "scout --config config_file export variants --json --case-id case_id"
 
+    command = ScoutExportCausativeVariants(case_id='case_id',config_file='config_file', scout_binary='/path/to/scout')
+
+    assert str(command) == "/path/to/scout --config config_file export variants --json --case-id case_id"
+
 def test_HousekeeperCommand():
 
     command = HousekeeperCommand(case_id='case_id', config_file='config_file')
 
     assert str(command) == "housekeeper --config config_file get -V case_id"
+
+    command = HousekeeperCommand(case_id='case_id', config_file='config_file', hk_binary='/path/to/housekeeper')
+
+    assert str(command) == "/path/to/housekeeper --config config_file get -V case_id"
+
+def test_MutaccExtract():
+
+    command = MutaccExtract('config_file', 300, 'case.yaml', mutacc_binary='/path/to/mutacc')
+
+    assert str(command) == "/path/to/mutacc --config-file config_file extract --padding 300 --case case.yaml"
+
+    command = MutaccExtract('config_file', 300, 'case.yaml')
+
+    assert str(command) == "mutacc --config-file config_file extract --padding 300 --case case.yaml"
+
+def test_MutaccImport():
+
+    command = MutaccImport('config_file', 'case', mutacc_binary='/path/to/mutacc')
+
+    assert str(command) == "/path/to/mutacc --config-file config_file db import case"
+
+    command = MutaccImport('config_file', 'case')
+
+    assert str(command) == "mutacc --config-file config_file db import case"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import yaml
 HK_OUT_FILE = "tests/fixtures/HK_output_test.txt"
 SCOUT_OUT_FILE = "tests/fixtures/scout_output.json"
 CASE_YAML = "tests/fixtures/case_input.yaml"
+CONFIG = "tests/fixtures/config_file.yaml"
 
 @pytest.fixture
 def housekeeper_output():
@@ -41,3 +42,8 @@ def scout_output():
         case = case_handle.read()
 
     return case
+    
+@pytest.fixture
+def configuration_file():
+
+    return CONFIG

--- a/tests/files/test_sbatch.py
+++ b/tests/files/test_sbatch.py
@@ -12,8 +12,7 @@ def test_SbatchScript(tmpdir):
 
     with SbatchScript(tmp_dir,
                       'mutacc_env',
-                      tmp_dir,
-                      'email') as sbatch_script:
+                      {'log_directory': tmp_dir, 'email':'email'}) as sbatch_script:
 
         sbatch_script.write_section('Command to run')
 
@@ -23,7 +22,7 @@ def test_SbatchScript(tmpdir):
 
     with SbatchScript(tmp_dir,
                      'mutacc_env',
-                      tmp_dir,
+                      {'log_directory': tmp_dir, 'email':'email', 'account':'account'},
                       conda=True) as sbatch_script:
 
         sbatch_script.write_section('Command to run')
@@ -31,8 +30,3 @@ def test_SbatchScript(tmpdir):
     sbatch_path = sbatch_script.path
 
     assert Path(sbatch_path).exists()
-
-
-def test_get_timestamp():
-
-    assert type(get_timestamp()) == str

--- a/tests/fixtures/case_input.yaml
+++ b/tests/fixtures/case_input.yaml
@@ -37,4 +37,4 @@ samples:
 
 #variant:
 #'variant_id', 'chromosome', 'position', 'alt', 'ref' must be given.
-variants: 'tests/fixtures/vcf_test.vcf'
+variants: 'tests/fixtures/test_vcf.vcf'

--- a/tests/fixtures/config_file.yaml
+++ b/tests/fixtures/config_file.yaml
@@ -1,0 +1,14 @@
+---
+scout_config: /path/to/scout_config
+scout_binary: /path/to/scout
+housekeeper_config: /path/to/housekeeper_config
+housekeeper_binary: /path/to/housekeeper
+mutacc_config: /path/to/mutacc_config
+mutacc_binary: /path/to/mutacc
+
+slurm:
+        log_directory: /path/to/log/
+        email: 'email.email@email.com'
+        time: '2:00:00'
+        account: 'account'
+        priority: 'low'

--- a/tests/recipes/test_extract_recipe.py
+++ b/tests/recipes/test_extract_recipe.py
@@ -13,14 +13,13 @@ def test_write_sbatch_script(tmpdir):
     sbatch_path = write_sbatch_script(tmp_dir,
                                       'environment',
                                       'mutacc extract ...',
-                                      tmp_dir,
-                                      'email')
+                                      {'log_directory': tmp_dir, 'email': 'email'})
 
     assert os.path.isfile(sbatch_path)
 
 def test_get_mutacc_extract_command():
 
-    mutacc_extract_command = MutAccExract('mutacc_conf', 699, 'input_file')
+    mutacc_extract_command = MutaccExtract('mutacc_conf', 699, 'input_file')
     true_command = "mutacc --config-file mutacc_conf extract --padding 699 --case input_file"
     assert str(mutacc_extract_command) == true_command
 
@@ -41,6 +40,5 @@ def test_run_mutacc_extract(mock_sbatch_run, tmpdir):
         'input_file',
         123,
         'env',
-        tmp_dir,
-        'email',
+        {'log_directory': tmp_dir, 'email': 'email'},
     )

--- a/tests/recipes/test_input_recipe.py
+++ b/tests/recipes/test_input_recipe.py
@@ -93,9 +93,9 @@ def test_get_inputs(mock_write_vcf, mock_get_bams, mock_get_cases, tmpdir, scout
 
     inputs = get_inputs(tmp_dir, days_ago = 1234)
 
-    mock_get_cases.assert_called_with(None,1234, scout_config=None)
-    mock_get_bams.assert_called_with('643594', hk_config=None)
-    mock_write_vcf.assert_called_with('643594', tmp_dir, scout_config=None)
+    mock_get_cases.assert_called_with(None,1234, scout_config=None, scout_binary=None)
+    mock_get_bams.assert_called_with('643594', hk_config=None, hk_binary=None)
+    mock_write_vcf.assert_called_with('643594', tmp_dir, scout_config=None, scout_binary=None)
 
     assert len(inputs) == 2
 


### PR DESCRIPTION
The user can now provide a config file to mutacc-auto. This config file can hold paths to configuration files for mutacc, scout, and housekeeper. It can also hold the binaries for the three apps. 
Additionaly, some slurm options can be specified in the config-file instead of via the CLI.

